### PR TITLE
feat(api): implementar endpoint POST /ingest/log con validación

### DIFF
--- a/src/collector/main.py
+++ b/src/collector/main.py
@@ -1,4 +1,5 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from src.contracts.events import LogEvent
 
 app = FastAPI()
 
@@ -15,3 +16,14 @@ def health_check():
     Si app esta viva, devuelve ok
     """
     return {"status": "ok"}
+
+@app.post("/ingest/log")
+def ingest_log(event: LogEvent):
+    """
+    Recibe un LogEvent, valida automáticamente el esquema y responde 200 OK.
+    """
+    try:
+        # Pydantic ya validó el JSON automáticamente al parsear
+        return {"status": "ok"}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))


### PR DESCRIPTION
Se implementó endpoint /ingest/log, cumpliéndose los criterios de aceptación:

**Criterios cumplidos:**
- [x] Usa los contratos definidos con Pydantic en src/contracts/events.py
- [x] Existe un endpoint POST /ingest/log que recibe datos.
- [x] Si los datos son válidos, retorna HTTP 200 OK.
- [x] Si no son válidos, retorna HTTP 422 Unprocessable Entity.

**Pruebas:**
<img width="1442" height="567" alt="imagen" src="https://github.com/user-attachments/assets/5772ac1a-4b08-4097-81f6-1cdefd672a96" />
