### PR TITLE
41 pruebas unitarias mocking

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,3 @@
 [run]
 omit =
     src/viewer/*
-    src/store/*

--- a/src/viewer/main.py
+++ b/src/viewer/main.py
@@ -50,5 +50,6 @@ def read_logs():
 
 @app.get("/logs")
 def get_logs():
-    logs = read_logs()
+    logs = read_logs() or []
+    logs = list(logs)
     return {"count": len(logs), "logs": logs}

--- a/tests/unit/test_collector.py
+++ b/tests/unit/test_collector.py
@@ -5,7 +5,6 @@ from datetime import datetime as Datetime
 import pytest
 import datetime
 from unittest.mock import patch, MagicMock
-from uuid import uuid4
 
 client = TestClient(app)
 
@@ -107,6 +106,7 @@ def test_invalid_log_returns_422(payload):
     response = client.post("/ingest/log", json=payload)
     assert response.status_code == 422
 
+
 client = TestClient(app)
 
 
@@ -141,6 +141,7 @@ def test_ingest_log_success(mock_client_cls):
 
     mock_client.post.assert_called_once()
 
+
 @patch("src.collector.main.httpx.Client")
 def test_ingest_log_store_down(mock_client_cls):
     mock_client = MagicMock()
@@ -154,11 +155,15 @@ def test_ingest_log_store_down(mock_client_cls):
     assert res.status_code == 200
     assert res.json() == {"status": "ok"}
 
-@pytest.mark.parametrize("exc", [
-    Exception("network down"),
-    ValueError("bad value"),
-    RuntimeError("unexpected"),
-])
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        Exception("network down"),
+        ValueError("bad value"),
+        RuntimeError("unexpected"),
+    ],
+)
 @patch("src.collector.main.httpx.Client")
 def test_ingest_log_parametrized_errors(mock_client_cls, exc):
     mock_client = MagicMock()

--- a/tests/unit/test_viewer.py
+++ b/tests/unit/test_viewer.py
@@ -2,7 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import patch
 
-from src.viewer.main import app, read_logs
+from src.viewer.main import app
 
 client = TestClient(app)
 
@@ -23,13 +23,16 @@ def test_get_logs_ok():
         response = client.get("/logs")
 
         assert response.status_code == 200
-        assert response.json() == {"count": 1 ,"logs": fake_logs}
+        assert response.json() == {"count": 1, "logs": fake_logs}
 
 
-@pytest.mark.parametrize("fake_logs", [
-    [],
-    None,
-])
+@pytest.mark.parametrize(
+    "fake_logs",
+    [
+        [],
+        None,
+    ],
+)
 def test_get_logs_edge_cases(fake_logs):
     with patch("src.viewer.main.read_logs", autospec=True, return_value=fake_logs):
         response = client.get("/logs")

--- a/tests/unit/test_viewer.py
+++ b/tests/unit/test_viewer.py
@@ -1,0 +1,36 @@
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+from src.viewer.main import app, read_logs
+
+client = TestClient(app)
+
+
+def test_get_logs_ok():
+    fake_logs = [
+        {
+            "id": "1",
+            "timestamp": "2024-01-01T10:00:00",
+            "service": "demo",
+            "level": "INFO",
+            "message": "hello",
+            "details": {"a": 1},
+        }
+    ]
+
+    with patch("src.viewer.main.read_logs", autospec=True, return_value=fake_logs):
+        response = client.get("/logs")
+
+        assert response.status_code == 200
+        assert response.json() == {"count": 1 ,"logs": fake_logs}
+
+
+@pytest.mark.parametrize("fake_logs", [
+    [],
+    None,
+])
+def test_get_logs_edge_cases(fake_logs):
+    with patch("src.viewer.main.read_logs", autospec=True, return_value=fake_logs):
+        response = client.get("/logs")
+        assert response.status_code == 200


### PR DESCRIPTION
Se implementaron las pruebas unitarias solicitadas en el issue.
Criterios cumplidos

- Se agregaron tests de Collector usando mock de `httpx.Client`
- Se agregaron tests de Viewer mockeando `read_logs()`  
- Se añadieron casos inválidos usando @pytest.mark.parametrize

**Prueba de ejecución:**
<img width="1430" height="329" alt="imagen" src="https://github.com/user-attachments/assets/faa4df48-8a17-4486-af5e-9fba1c0d899c" />
Se añadiran más pruebas para subir la cobertura en un futuro sprint