### PR TITLE
56 actualizar viewer api y cobertura

### DIFF
--- a/src/viewer/main.py
+++ b/src/viewer/main.py
@@ -65,3 +65,114 @@ def get_logs():
     logs = read_logs() or []
     logs = list(logs)
     return {"count": len(logs), "logs": logs}
+
+def read_metrics():
+    if not DB_PATH.exists():
+        return []
+
+    try:
+        conn = sqlite3.connect(DB_PATH)
+        cursor = conn.cursor()
+        
+        """
+        CREATE TABLE IF NOT EXISTS metrics (
+            id TEXT PRIMARY KEY,
+            timestamp TEXT,
+            service TEXT,
+            name TEXT,
+            value REAL,
+            tags TEXT
+        )
+        """
+
+        cursor.execute(
+            "SELECT id, timestamp, service, name, value, tags FROM metrics"
+        )
+        raw_metrics = cursor.fetchall()
+
+        conn.close()
+
+        metrics = []
+        for metric_info in raw_metrics:
+
+            tags_as_dict = json.loads(metric_info[5]) if metric_info[5] else None
+
+            metrics.append(
+                {
+                    "id": metric_info[0],
+                    "timestamp": metric_info[1],
+                    "service": metric_info[2],
+                    "name": metric_info[3],
+                    "value": metric_info[4],
+                    "tags": tags_as_dict,
+                }
+            )
+        return metrics
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/metrics")
+def get_metrics():
+    metrics = read_metrics() or []
+    metrics = list(metrics)
+    return {"count": len(metrics), "metrics": metrics}
+
+def read_traces():
+    if not DB_PATH.exists():
+        return []
+
+    try:
+        conn = sqlite3.connect(DB_PATH)
+        cursor = conn.cursor()
+        
+        """
+        id: UUID
+        timestamp: datetime
+        service: str = Field(..., min_length=1)
+        trace_id: UUID
+        span_id: UUID
+        parent_span_id: Optional[UUID] = None
+        name: str = Field(..., min_length=1)
+        duration: float
+        tags: Dict[str, str]
+        """
+
+        cursor.execute(
+            "SELECT id, timestamp, service, trace_id, span_id, parent_span_id, name, duration, tags FROM traces"
+        )
+        raw_traces = cursor.fetchall()
+
+        conn.close()
+
+        traces = []
+        for trace_info in raw_traces:
+
+            tags_as_dict = json.loads(trace_info[8]) if trace_info[8] else {}
+            parent_span_id = trace_info[5] if trace_info[5] else None
+
+            traces.append(
+                {
+                    "id": trace_info[0],
+                    "timestamp": trace_info[1],
+                    "service": trace_info[2],
+                    "trace_id": trace_info[3],
+                    "span_id": trace_info[4],
+                    "parent_span_id": parent_span_id,
+                    "name": trace_info[6],
+                    "duration": trace_info[7],
+                    "tags": tags_as_dict,
+                }
+            )
+        return traces
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/traces")
+def get_traces():
+    traces = read_traces() or []
+    traces = list(traces)
+    return {"count": len(traces), "traces": traces}

--- a/src/viewer/main.py
+++ b/src/viewer/main.py
@@ -66,6 +66,7 @@ def get_logs():
     logs = list(logs)
     return {"count": len(logs), "logs": logs}
 
+
 def read_metrics():
     if not DB_PATH.exists():
         return []
@@ -73,7 +74,7 @@ def read_metrics():
     try:
         conn = sqlite3.connect(DB_PATH)
         cursor = conn.cursor()
-        
+
         """
         CREATE TABLE IF NOT EXISTS metrics (
             id TEXT PRIMARY KEY,
@@ -85,9 +86,7 @@ def read_metrics():
         )
         """
 
-        cursor.execute(
-            "SELECT id, timestamp, service, name, value, tags FROM metrics"
-        )
+        cursor.execute("SELECT id, timestamp, service, name, value, tags FROM metrics")
         raw_metrics = cursor.fetchall()
 
         conn.close()
@@ -119,6 +118,7 @@ def get_metrics():
     metrics = list(metrics)
     return {"count": len(metrics), "metrics": metrics}
 
+
 def read_traces():
     if not DB_PATH.exists():
         return []
@@ -126,7 +126,7 @@ def read_traces():
     try:
         conn = sqlite3.connect(DB_PATH)
         cursor = conn.cursor()
-        
+
         """
         id: UUID
         timestamp: datetime
@@ -140,7 +140,9 @@ def read_traces():
         """
 
         cursor.execute(
-            "SELECT id, timestamp, service, trace_id, span_id, parent_span_id, name, duration, tags FROM traces"
+            "SELECT id, timestamp, service, trace_id, span_id, "
+            "parent_span_id, name, duration, tags "
+            "FROM traces"
         )
         raw_traces = cursor.fetchall()
 

--- a/tests/unit/test_viewer.py
+++ b/tests/unit/test_viewer.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import json
 import sqlite3
 
-from src.viewer.main import app, read_logs
+from src.viewer.main import app, read_logs, read_metrics, read_traces
 
 client = TestClient(app)
 
@@ -97,3 +97,193 @@ def test_read_logs_success(tmp_path, monkeypatch):
     assert len(logs) == 1
     assert logs[0]["id"] == "123"
     assert logs[0]["details"] == {"a": "b"}
+
+#---metrics
+
+def test_get_metrics_ok():
+    fake_metrics = [
+        {
+            "id": "123",
+            "timestamp": "2024-10-10T10:00:00",
+            "service": "api",
+            "name": "metric.g",
+            "value": 1.23,
+            "tags": {"env": "test"},
+        }
+    ]
+
+    with patch("src.viewer.main.read_metrics", autospec=True, return_value=fake_metrics):
+        response = client.get("/metrics")
+
+        assert response.status_code == 200
+        assert response.json() == {"count": 1, "metrics": fake_metrics}
+
+
+@pytest.mark.parametrize(
+    "fake_metrics",
+    [
+        [],
+        None,
+    ],
+)
+def test_get_metrics_edge_cases(fake_metrics):
+    with patch("src.viewer.main.read_metrics", autospec=True, return_value=fake_metrics):
+        response = client.get("/metrics")
+        assert response.status_code == 200
+
+def test_read_metrics_returns_empty_if_db_not_exists(tmp_path, monkeypatch):
+    fake_db = tmp_path / "no_db.db"
+    monkeypatch.setattr("src.viewer.main.DB_PATH", fake_db)
+
+    result = read_metrics()
+    assert result == []
+
+
+def test_read_metrics_success(tmp_path, monkeypatch):
+    db_file = tmp_path / "metrics.db"
+    monkeypatch.setattr("src.viewer.main.DB_PATH", db_file)
+
+    conn = sqlite3.connect(db_file)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE metrics (
+            id TEXT PRIMARY KEY,
+            timestamp TEXT,
+            service TEXT,
+            name TEXT,
+            value REAL,
+            tags TEXT
+        )
+        """
+    )
+    cursor.execute(
+        """
+            INSERT INTO metrics (id, timestamp, service, name, value, tags)
+            VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "123",
+            "2024-10-10T10:00:00",
+            "svc",
+            "ejemplo",
+            12.3,
+            json.dumps({"a": "b"}),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    # Ejecutar
+    metrics = read_metrics()
+
+    assert isinstance(metrics, list)
+    assert len(metrics) == 1
+    assert metrics[0]["id"] == "123"
+    assert metrics[0]["tags"] == {"a": "b"}
+
+#---traces
+
+def test_get_traces_ok():
+    fake_traces = [
+        {
+            "id": "123",
+            "timestamp": "2024-10-10T10:00:00",
+            "service": "servicio-ejemplo",
+            "trace_id": "456",
+            "span_id": "789",
+            "parent_span_id": "159",  # opcional
+            "name": "ejemplo",
+            "duration": 67.67,
+            "tags": {"status": "ok"},
+        }
+    ]
+
+    with patch("src.viewer.main.read_traces", autospec=True, return_value=fake_traces):
+        response = client.get("/traces")
+
+        assert response.status_code == 200
+        assert response.json() == {"count": 1, "traces": fake_traces}
+
+
+@pytest.mark.parametrize(
+    "fake_traces",
+    [
+        [],
+        None,
+    ],
+)
+def test_get_traces_edge_cases(fake_traces):
+    with patch("src.viewer.main.read_traces", autospec=True, return_value=fake_traces):
+        response = client.get("/traces")
+        assert response.status_code == 200
+
+def test_read_traces_returns_empty_if_db_not_exists(tmp_path, monkeypatch):
+    fake_db = tmp_path / "no_db.db"
+    monkeypatch.setattr("src.viewer.main.DB_PATH", fake_db)
+
+    result = read_traces()
+    assert result == []
+
+
+def test_read_traces_success(tmp_path, monkeypatch):
+    db_file = tmp_path / "traces.db"
+    monkeypatch.setattr("src.viewer.main.DB_PATH", db_file)
+
+    conn = sqlite3.connect(db_file)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE traces (
+            id TEXT PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            service TEXT NOT NULL,
+            trace_id TEXT NOT NULL,
+            span_id TEXT NOT NULL,
+            parent_span_id TEXT,
+            name TEXT NOT NULL,
+            duration REAL NOT NULL,
+            tags TEXT
+        )
+        """
+    )
+    cursor.execute(
+        """
+            INSERT INTO traces (
+                id,
+                timestamp,
+                service,
+                trace_id,
+                span_id,
+                parent_span_id,
+                name,
+                duration,
+                tags
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+        (
+            "123",
+            "2024-10-10T10:00:00",
+            "svc",
+            "456",
+            "789",
+            "159",
+            "ejemplo",
+            12.3,
+            json.dumps({"a": "b"}),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    # Ejecutar
+    traces = read_traces()
+
+    assert isinstance(traces, list)
+    assert len(traces) == 1
+    assert traces[0]["id"] == "123"
+    assert traces[0]["trace_id"] == "456"
+    assert traces[0]["span_id"] == "789"
+    assert traces[0]["parent_span_id"] == "159"
+    assert traces[0]["tags"] == {"a": "b"}

--- a/tests/unit/test_viewer.py
+++ b/tests/unit/test_viewer.py
@@ -98,7 +98,9 @@ def test_read_logs_success(tmp_path, monkeypatch):
     assert logs[0]["id"] == "123"
     assert logs[0]["details"] == {"a": "b"}
 
-#---metrics
+
+# ---metrics
+
 
 def test_get_metrics_ok():
     fake_metrics = [
@@ -112,7 +114,9 @@ def test_get_metrics_ok():
         }
     ]
 
-    with patch("src.viewer.main.read_metrics", autospec=True, return_value=fake_metrics):
+    with patch(
+        "src.viewer.main.read_metrics", autospec=True, return_value=fake_metrics
+    ):
         response = client.get("/metrics")
 
         assert response.status_code == 200
@@ -127,9 +131,12 @@ def test_get_metrics_ok():
     ],
 )
 def test_get_metrics_edge_cases(fake_metrics):
-    with patch("src.viewer.main.read_metrics", autospec=True, return_value=fake_metrics):
+    with patch(
+        "src.viewer.main.read_metrics", autospec=True, return_value=fake_metrics
+    ):
         response = client.get("/metrics")
         assert response.status_code == 200
+
 
 def test_read_metrics_returns_empty_if_db_not_exists(tmp_path, monkeypatch):
     fake_db = tmp_path / "no_db.db"
@@ -182,7 +189,9 @@ def test_read_metrics_success(tmp_path, monkeypatch):
     assert metrics[0]["id"] == "123"
     assert metrics[0]["tags"] == {"a": "b"}
 
-#---traces
+
+# ---traces
+
 
 def test_get_traces_ok():
     fake_traces = [
@@ -217,6 +226,7 @@ def test_get_traces_edge_cases(fake_traces):
     with patch("src.viewer.main.read_traces", autospec=True, return_value=fake_traces):
         response = client.get("/traces")
         assert response.status_code == 200
+
 
 def test_read_traces_returns_empty_if_db_not_exists(tmp_path, monkeypatch):
     fake_db = tmp_path / "no_db.db"


### PR DESCRIPTION
Se implementó `/metrics` y `/traces` en el viewer, asi como tests para estos

**Criterios cumplidos:**

- Implementado endpoints `/metrics` y `/traces` en viewer
- Añadido tests para estos, cobertura mayor a 90%

**Pruebas:**
<img width="562" height="447" alt="imagen" src="https://github.com/user-attachments/assets/003bcab5-c3f1-47b5-a9cb-383a4e78119a" />
<img width="562" height="447" alt="imagen" src="https://github.com/user-attachments/assets/4097190a-7582-41c3-aad4-1434ada10ef4" />
<img width="601" height="503" alt="imagen" src="https://github.com/user-attachments/assets/4353b161-b77c-430a-a565-3614f843f61f" />
<img width="1063" height="261" alt="imagen" src="https://github.com/user-attachments/assets/c4203774-be2d-4adc-8c65-10f4dcfc6831" />
